### PR TITLE
Explicitly set visibility=default on getFactoryMap.

### DIFF
--- a/include/fastcgi2/component_factory.h
+++ b/include/fastcgi2/component_factory.h
@@ -55,8 +55,16 @@ public:
 
 typedef fastcgi::FactoryMap* (*FastcgiGetFactoryMapFunction)();
 
+#if __GNUC__ >= 4
+#	define FCGIDAEMON_DSO_GLOBALLY_VISIBLE \
+		__attribute__ ((visibility ("default")))
+#else
+#	define FCGIDAEMON_DSO_GLOBALLY_VISIBLE
+#endif
+
 #define FCGIDAEMON_REGISTER_FACTORIES_BEGIN() \
-	extern "C" const fastcgi::FactoryMap* getFactoryMap() { \
+	extern "C" FCGIDAEMON_DSO_GLOBALLY_VISIBLE \
+	const fastcgi::FactoryMap* getFactoryMap() { \
 		static fastcgi::FactoryMap m;
 			        
 #define FCGIDAEMON_ADD_DEFAULT_FACTORY(name, Type) \


### PR DESCRIPTION
This enables the user to export only getFactoryMap
from his component by compiling with -fvisibility=hidden,
as recommended in the DSO HOWTO
(www.akkadia.org/drepper/dsohowto.pdf).
