### PR TITLE
Added configurable time format to file logger

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+fastcgi-daemon2 (2.10-17) unstable; urgency=low
+
+  * Added configurable time format to file logger
+
+ -- Konstantin Karganov <karganov@yandex-team.ru>  Tue, 22 Jan 2013 18:02:08 +0400
+
 fastcgi-daemon2 (2.10-16) unstable; urgency=low
 
   * fixed copy/past

--- a/file-logger/file_logger.cpp
+++ b/file-logger/file_logger.cpp
@@ -43,6 +43,8 @@ FileLogger::FileLogger(ComponentContext *context) : Component(context),
     print_time_ =
         (0 == strcasecmp(config->asString(componentXPath + "/print-time", "yes").c_str(), "yes"));
 
+    time_format_ = config->asString(componentXPath + "/time-format", "[%Y/%m/%d %T]");
+
     std::string read = config->asString(componentXPath + "/read", "");
     if (!read.empty()) {
         if (read == "all") {
@@ -142,7 +144,7 @@ FileLogger::prepareFormat(char * buf, size_t size, const Logger::Level level, co
         time_t t;
         time(&t);
         localtime_r(&t, &tm);
-        strftime(timestr, sizeof(timestr) - 1, "[%Y/%m/%d %T]", &tm);
+        strftime(timestr, sizeof(timestr) - 1, time_format_.c_str(), &tm);
     }
 
     std::string level_str;

--- a/file-logger/file_logger.h
+++ b/file-logger/file_logger.h
@@ -31,6 +31,9 @@ private:
     // Open mode
     mode_t openMode_;
 
+    // Time format specification
+    std::string time_format_;
+
     bool print_level_;
     bool print_time_;
 


### PR DESCRIPTION
Using fastcgi-filelogger now it is possible to specify custom timestamp format.
Old format is used by default, so doesn't break backwards compatibility.
