### PR TITLE
fixed failed assertion during thread pool destruction

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+fastcgi-daemon2 (2.10-23) lucid; urgency=low
+
+  * fixed failed assertion during thread pool destruction
+
+ -- Mikhail Khokhlov <aeol@yandex-team.ru>  Wed, 19 Feb 2014 12:02:00 +0400
+
 fastcgi-daemon2 (2.10-22) unstable; urgency=low
 
   * Fixed crash in worker threads when server is being stopped

--- a/include/details/thread_pool.h
+++ b/include/details/thread_pool.h
@@ -60,6 +60,8 @@ public:
 	}
 
 	virtual ~ThreadPool() {
+		stop();
+		join();
 	}
 
 	void start(InitFuncType func) {


### PR DESCRIPTION
Fixes errors like these:
/usr/include/boost/thread/pthread/condition_variable.hpp:71: 
boost::condition_variable_any::~condition_variable_any(): Assertion `!pthread_mutex_destroy(&internal_mutex)' failed.

that appear when exception is raised during initialization stage (e.g. busy socket).
