### PR TITLE
Fix problem in filelogger which resulted in broken log entries

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+fastcgi-daemon2 (2.10-27) lucid; urgency=low
+
+  * Fix broken log entries in file logger
+  * Fix request filter condition check
+
+ -- Konstantin Karganov <karganov@yandex-team.ru>  Tue, 28 Oct 2014 10:20:37 +0400
+
 fastcgi-daemon2 (2.10-26) lucid; urgency=low
 
   * Fixed syslog format string usage

--- a/file-logger/file_logger.cpp
+++ b/file-logger/file_logger.cpp
@@ -181,7 +181,17 @@ FileLogger::writingThread() {
         boost::mutex::scoped_lock fdlock(fdMutex_);
         if (fd_ != -1) {
             for (std::vector<std::string>::iterator i = queueCopy.begin(); i != queueCopy.end(); ++i) {
-                ::write(fd_, i->c_str(), i->length());
+                size_t wrote = 0;
+                while( wrote < i->length()) {
+                    int res = ::write(fd_, i->c_str() + wrote, i->length() - wrote);
+                    if (res < 0) {
+                        std::cerr << "Failed to write to log " << filename_ << " : " << strerror(errno) << std::endl;
+                        break;
+                    }
+                    else {
+                        wrote += res;
+                    }
+                }
             }
         }
     }

--- a/library/request_filter.cpp
+++ b/library/request_filter.cpp
@@ -79,7 +79,9 @@ RefererFilter::~RefererFilter()
 
 bool
 RefererFilter::check(const Request *request) const {
-    if (!request->hasHeader("Referer"));
+    if (!request->hasHeader("Referer")) {
+        return false;
+    }
 
     return regex_.check(request->getHeader("Referer"));
 }


### PR DESCRIPTION
write() is not guaranteed to write all data at once and under high load we got log messages with broken format, after this patch the problem seems to have been fixed.