### PR TITLE
Implement request flush method

### DIFF
--- a/include/details/requestimpl.h
+++ b/include/details/requestimpl.h
@@ -158,6 +158,8 @@ public:
 	
 	unsigned short status() const;
 
+	void flush();
+
 private:
 	friend class Parser;
 	void sendHeadersInternal();

--- a/include/fastcgi2/request.h
+++ b/include/fastcgi2/request.h
@@ -119,6 +119,8 @@ public:
 
     unsigned short status() const;
 
+    void flush();
+
 private:
     std::auto_ptr<RequestImpl> impl_;
 };

--- a/include/fastcgi2/request_io_stream.h
+++ b/include/fastcgi2/request_io_stream.h
@@ -26,6 +26,7 @@ public:
 	virtual int read(char *buf, int size) = 0;
 	virtual int write(const char *buf, int size) = 0;
 	virtual void write(std::streambuf *buf) = 0;
+	virtual void flush() = 0;
 };
 
 } // namespace fastcgi

--- a/library/request.cpp
+++ b/library/request.cpp
@@ -314,4 +314,9 @@ Request::status() const {
     return impl_->status();
 }
 
+void
+Request::flush() {
+    impl_->flush();
+}
+
 } // namespace fastcgi

--- a/library/requestimpl.cpp
+++ b/library/requestimpl.cpp
@@ -851,4 +851,11 @@ RequestImpl::status() const {
 	return status_;
 }
 
+void
+RequestImpl::flush() {
+	if (stream_) {
+		stream_->flush();
+	}
+}
+
 } // namespace fastcgi

--- a/main/fcgi_request.cpp
+++ b/main/fcgi_request.cpp
@@ -161,4 +161,23 @@ FastcgiRequest::setHandlerDesc(const HandlerSet::HandlerDescription *handler) {
     handler_ = handler;
 }
 
+void
+FastcgiRequest::flush() {
+    int num = FCGX_FFlush(fcgiRequest_.out);
+    if (-1 == num) {
+        std::stringstream str;
+        int error = FCGX_GetError(fcgiRequest_.out);
+        if (error > 0) {
+            char buffer[256];
+            str << "Cannot flush data to fastcgi socket: " <<
+                strerror_r(error, buffer, sizeof(buffer)) << ". ";
+        }
+        else {
+            str << "FastCGI error. ";
+        }
+        generateRequestInfo(request_.get(), str);
+        throw std::runtime_error(str.str());
+    }
+}
+
 } // namespace fastcgi

--- a/main/fcgi_request.h
+++ b/main/fcgi_request.h
@@ -35,6 +35,7 @@ public:
 	void write(std::streambuf *buf);
 
 	void setHandlerDesc(const HandlerSet::HandlerDescription *handler);
+	void flush();
 private:
 	boost::shared_ptr<Request> request_;
     Logger *logger_;

--- a/request-cache/file_cache.cpp
+++ b/request-cache/file_cache.cpp
@@ -75,6 +75,8 @@ public:
 	void write(std::streambuf *buf) {
 		(void)buf;
 	}
+	void flush() {
+	}
 };
 
 FileRequestCache::FileRequestCache(ComponentContext *context) :

--- a/tests/test_request.cpp
+++ b/tests/test_request.cpp
@@ -81,6 +81,8 @@ public:
 	virtual void write(std::streambuf *buf) {
 		(*out_) << buf;
 	}
+	virtual void flush() {
+	}
 private:
 	std::istream *in_;
 	std::ostream *out_;


### PR DESCRIPTION
This method becomes handy when we need to force sending response to the client without finishing handler right away, otherwise internal buffers of libfcgi can held the response.